### PR TITLE
Fix quill image sizing

### DIFF
--- a/app/assets/javascripts/decidim/decidim_awesome/editors/legacy_quill_editor.js.es6
+++ b/app/assets/javascripts/decidim/decidim_awesome/editors/legacy_quill_editor.js.es6
@@ -13,7 +13,7 @@
   // Redefines Quill editor with images
   if(exports.DecidimAwesome.allow_images_in_full_editor  || exports.DecidimAwesome.allow_images_in_small_editor || exports.DecidimAwesome.use_markdown_editor) {
 
-    const quillFormats = ["bold", "italic", "link", "underline", "header", "list", "video", "image", "alt", "break", "width"];
+    const quillFormats = ["bold", "italic", "link", "underline", "header", "list", "video", "image", "alt", "width"];
 
     const createQuillEditor = (container) => {
       const toolbar = $(container).data("toolbar");

--- a/app/assets/javascripts/decidim/decidim_awesome/editors/legacy_quill_editor.js.es6
+++ b/app/assets/javascripts/decidim/decidim_awesome/editors/legacy_quill_editor.js.es6
@@ -13,7 +13,7 @@
   // Redefines Quill editor with images
   if(exports.DecidimAwesome.allow_images_in_full_editor  || exports.DecidimAwesome.allow_images_in_small_editor || exports.DecidimAwesome.use_markdown_editor) {
 
-    const quillFormats = ["bold", "italic", "link", "underline", "header", "list", "video", "image", "alt"];
+    const quillFormats = ["bold", "italic", "link", "underline", "header", "list", "video", "image", "alt", "break", "width"];
 
     const createQuillEditor = (container) => {
       const toolbar = $(container).data("toolbar");

--- a/app/assets/javascripts/decidim/decidim_awesome/editors/quill_editor.js.es6
+++ b/app/assets/javascripts/decidim/decidim_awesome/editors/quill_editor.js.es6
@@ -14,7 +14,7 @@
   // Redefines Quill editor with images
   if(exports.DecidimAwesome.allow_images_in_full_editor  || exports.DecidimAwesome.allow_images_in_small_editor || exports.DecidimAwesome.use_markdown_editor) {
 
-    const quillFormats = ["bold", "italic", "link", "underline", "header", "list", "video", "image", "alt", "width"];
+    const quillFormats = ["bold", "italic", "link", "underline", "header", "list", "video", "image", "alt", "break", "width"];
 
     const createQuillEditor = (container) => {
       const toolbar = $(container).data("toolbar");

--- a/app/assets/javascripts/decidim/decidim_awesome/editors/quill_editor.js.es6
+++ b/app/assets/javascripts/decidim/decidim_awesome/editors/quill_editor.js.es6
@@ -14,7 +14,7 @@
   // Redefines Quill editor with images
   if(exports.DecidimAwesome.allow_images_in_full_editor  || exports.DecidimAwesome.allow_images_in_small_editor || exports.DecidimAwesome.use_markdown_editor) {
 
-    const quillFormats = ["bold", "italic", "link", "underline", "header", "list", "video", "image", "alt", "break", "width"];
+    const quillFormats = ["bold", "italic", "link", "underline", "header", "list", "video", "image", "alt", "width"];
 
     const createQuillEditor = (container) => {
       const toolbar = $(container).data("toolbar");

--- a/app/assets/javascripts/decidim/decidim_awesome/editors/quill_editor.js.es6
+++ b/app/assets/javascripts/decidim/decidim_awesome/editors/quill_editor.js.es6
@@ -14,7 +14,7 @@
   // Redefines Quill editor with images
   if(exports.DecidimAwesome.allow_images_in_full_editor  || exports.DecidimAwesome.allow_images_in_small_editor || exports.DecidimAwesome.use_markdown_editor) {
 
-    const quillFormats = ["bold", "italic", "link", "underline", "header", "list", "video", "image", "alt", "break"];
+    const quillFormats = ["bold", "italic", "link", "underline", "header", "list", "video", "image", "alt", "break", "width"];
 
     const createQuillEditor = (container) => {
       const toolbar = $(container).data("toolbar");


### PR DESCRIPTION
Hello

#### Description

When a user add an image in editor, and resizes the image, the width is no longer present on reload. 

#### Fixes

Fixes : #98 

#### Screenshot

**Before fix, on reload**
<img width="400" alt="Screenshot 2021-12-21 at 12 22 02" src="https://user-images.githubusercontent.com/26109239/146922173-c3fd5259-8caf-4fad-b3ee-9c0959d90c3e.png">

**After fix, on reload**
<img width="400" alt="Screenshot 2021-12-21 at 12 22 40" src="https://user-images.githubusercontent.com/26109239/146922215-4feaf063-6c26-4320-9df2-97c19fdad422.png">


