### PR TITLE
Fix path of icons in manifest of some components declared by decidim-awesome

### DIFF
--- a/lib/decidim/decidim_awesome/iframe_component/component.rb
+++ b/lib/decidim/decidim_awesome/iframe_component/component.rb
@@ -5,7 +5,7 @@ require "decidim/components/namer"
 Decidim::DecidimAwesome.register_component(:awesome_iframe) do |component|
   component.engine = Decidim::DecidimAwesome::IframeComponent::Engine
   component.admin_engine = Decidim::DecidimAwesome::IframeComponent::AdminEngine
-  component.icon = "decidim/meetings/icon.svg" # TODO: create a Icon
+  component.icon = "media/images/decidim_meetings.svg" # TODO: create a Icon
   component.permissions_class_name = "Decidim::DecidimAwesome::Permissions"
 
   # These actions permissions can be configured in the admin panel

--- a/lib/decidim/decidim_awesome/map_component/component.rb
+++ b/lib/decidim/decidim_awesome/map_component/component.rb
@@ -5,7 +5,7 @@ require "decidim/components/namer"
 Decidim::DecidimAwesome.register_component(:awesome_map) do |component|
   component.engine = Decidim::DecidimAwesome::MapComponent::Engine
   component.admin_engine = Decidim::DecidimAwesome::MapComponent::AdminEngine
-  component.icon = "decidim/meetings/icon.svg" # TODO: create a Icon
+  component.icon = "media/images/decidim_meetings.svg" # TODO: create a Icon
   component.permissions_class_name = "Decidim::DecidimAwesome::Permissions"
 
   # These actions permissions can be configured in the admin panel


### PR DESCRIPTION
This PR updates the paths declared in manifests of components defined by the module.

The old paths can generate exceptions for example when an admin publish one of this components and visits her notifications.